### PR TITLE
Plando Items: Fix Location Groups Unfolding

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -923,9 +923,9 @@ def parse_planned_blocks(multiworld: MultiWorld) -> dict[int, list[PlandoItemBlo
             if isinstance(locations, str):
                 locations = [locations]
 
-            locations_from_groups: list[str] = []
             resolved_locations: list[Location] = []
             for target_player in worlds:
+                locations_from_groups: list[str] = []
                 world_locations = multiworld.get_unfilled_locations(target_player)
                 for group in multiworld.worlds[target_player].location_name_groups:
                     if group in locations:


### PR DESCRIPTION
## What is this fixing or adding?

When unfolding location groups, plando could add in locations from a group that didn't match the player the group came from. So if multiple worlds had identical location names, they could get added as expected locations when they shouldn't be, and the behavior depended upon the player order.

## How was this tested?

Using these two files, where Emerald includes this plando block:
```yaml
  plando_items:
    - item: Pearl
      location: Pokedex
      world: null
      force: true
```
And seeing that before this change, the `Pokedex` location group would expand and include Pokemon Red/Blue's locations (which happen to have the same name as Emerald's), if Emerald resolved before R/B. This would happen despite the fact that "Pokedex" is not a valid group name in Red/Blue.

The resolved locations were check by just doing `print(resolved_locations)` after the `for` loop.

[Pokemon Emerald.json](https://github.com/user-attachments/files/20677477/Pokemon.Emerald.json)
[Pokemon Red and Blue.json](https://github.com/user-attachments/files/20677478/Pokemon.Red.and.Blue.json)