### PR TITLE
Docs: Don't Suggest exclude `create_items` Method

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -612,17 +612,10 @@ def create_items(self) -> None:
     # If there are two of the same item, the item has to be twice in the pool.
     # Which items are added to the pool may depend on player options, e.g. custom win condition like triforce hunt.
     # Having an item in the start inventory won't remove it from the pool.
-    # If an item can't have duplicates it has to be excluded manually.
-
-    # List of items to exclude, as a copy since it will be destroyed below
-    exclude = [item for item in self.multiworld.precollected_items[self.player]]
+    # If you want to do that, use start_inventory_from_pool
 
     for item in map(self.create_item, mygame_items):
-        if item in exclude:
-            exclude.remove(item)  # this is destructive. create unique list above
-            self.multiworld.itempool.append(self.create_item("nothing"))
-        else:
-            self.multiworld.itempool.append(item)
+        self.multiworld.itempool.append(item)
 
     # itempool and number of locations should match up.
     # If this is not the case we want to fill the itempool with junk.


### PR DESCRIPTION
## What is this fixing or adding?

We don't need to suggest this `exclude` method anymore because `start_inventory_from_pool` (SIFP) exists and should, in many cases, be used instead.

## How was this tested?

👀